### PR TITLE
Allow stylelint ^15 as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-no-restricted-syntax",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Stylelint rule to disallow specified syntax.",
   "license": "MIT",
   "author": "Ivan Nikolić <niksy5@gmail.com> (http://ivannikolic.com)",
@@ -79,7 +79,7 @@
     "version-changelog": "^3.1.1"
   },
   "peerDependencies": {
-    "stylelint": "^14.0.0"
+    "stylelint": "^15.0.0 || ^14.0.0"
   },
   "engines": {
     "node": ">=12"

--- a/test/index.js
+++ b/test/index.js
@@ -34,6 +34,8 @@ runCodeTest({
 			result: [
 				{
 					column: 1,
+					endColumn: 23,
+					endLine: 1,
 					line: 1,
 					text: messages.report('Anchors not allowed.')
 				}
@@ -44,6 +46,8 @@ runCodeTest({
 			result: [
 				{
 					column: 5,
+					endColumn: 15,
+					endLine: 1,
 					line: 1,
 					text: messages.report('z-index not allowed.')
 				}


### PR DESCRIPTION
Are the maintainers (@niksy) open to upgrading this plugin to work with Stylelint 15? I'm digging in right now and it looks like there might be some rewrites necessary, even though the package seems to work when installed with `--force`.

Note: currently work-in-progress. Just poking around.