### PR TITLE
Allow function error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,33 @@ Add this config to your `.stylelintrc`:
 }
 ```
 
+If using a JavaScript config file (e.g., `stylelint.config.cjs`), you may also
+use a function that returns a message:
+
+```js
+module.exports = {
+	'plugins': ['stylelint-no-restricted-syntax'],
+	'rules': {
+		'plugin/no-restricted-syntax': [
+			[
+				{
+					'selector': "decl[prop='z-index']",
+					'message': (node) => `${node.prop} not allowed.`
+				}
+			]
+		]
+	}
+};
+```
+
 ## Options
 
 Each restricted syntax rule consists of the following properties:
 
-| Property   | Type     | Description                             |
-| ---------- | -------- | --------------------------------------- |
-| `selector` | `string` | Selector for querying PostCSS AST.      |
-| `message`  | `string` | Error message for queried PostCSS node. |
+| Property   | Type               | Description                                                                                                  |
+| ---------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `selector` | `string`           | Selector for querying PostCSS AST.                                                                           |
+| `message`  | `string\|function` | Error message for queried PostCSS node. If using a function, the provided argument is the full PostCSS node. |
 
 ## Details
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 /**
- * @typedef {object} Declaration
+ * @typedef {import('postcss').AnyNode} AnyNode
+ *
  * @typedef {object} SyntaxRule
- * @property {string}          selector Selector for querying PostCSS AST.
- * @property {Function|string} message  Error message for queried PostCSS node.
+ * @property {string}         selector Selector for querying PostCSS AST.
+ * @property {Message|string} message  Error message for queried PostCSS node.
+ *
+ * @typedef {(node: AnyNode) => string} Message
  */
 
 import stylelint from 'stylelint';
@@ -11,8 +14,8 @@ import queryAst from 'postcss-query-ast';
 const ruleName = 'plugin/no-restricted-syntax';
 
 /**
- * @param   {Function|string} message
- * @param   {Declaration}     node
+ * @param   {Message|string} message
+ * @param   {AnyNode}        node
  * @returns {string}
  */
 const generateMessage = (message, node) =>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 /**
+ * @typedef {object} Declaration
  * @typedef {object} SyntaxRule
  * @property {string} selector Selector for querying PostCSS AST.
  * @property {string} message  Error message for queried PostCSS node.
@@ -10,7 +11,19 @@ import queryAst from 'postcss-query-ast';
 const ruleName = 'plugin/no-restricted-syntax';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
-	report: (/** @type string */ message) => message
+	/**
+	 * @param {function|string} message
+	 * @param {Declaration} node
+	 * @returns
+	 */
+	report: (message, node) => {
+		if (typeof message === 'function') {
+			return message(node)
+		}
+		if (typeof message === 'string') {
+			return message;
+		}
+	}
 });
 
 /**
@@ -56,7 +69,7 @@ function ruleFunction(/** @type {SyntaxRule[]}*/ syntaxRules) {
 						ruleName: ruleName,
 						result: result,
 						node: node,
-						message: messages.report(message)
+						message: messages.report(message, node)
 					});
 				});
 			});

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,8 @@
+/**
+ * @typedef {import('postcss').Declaration} Declaration
+ * @typedef {import('../index.js').SyntaxRule} SyntaxRule
+ */
+
 import function_ from '../index.js';
 import { runCodeTest } from './util/index.js';
 
@@ -7,7 +12,7 @@ const { ruleName } = function_;
 runCodeTest({
 	ruleName: ruleName,
 	config: [
-		[
+		/** @type Array<SyntaxRule> */ ([
 			{
 				selector: 'rule[selector="a"]',
 				message: 'Anchors not allowed.'
@@ -18,10 +23,10 @@ runCodeTest({
 			},
 			{
 				selector: 'decl[prop="zoom"]',
-				// @ts-ignore
-				message: (node) => `${node.prop} not allowed.`
+				message: (node) =>
+					`${/** @type Declaration */ (node).prop} not allowed.`
 			}
-		]
+		])
 	],
 
 	accept: [

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ import function_ from '../index.js';
 import { runCodeTest } from './util/index.js';
 
 // @ts-ignore
-const { ruleName, messages } = function_;
+const { ruleName } = function_;
 
 runCodeTest({
 	ruleName: ruleName,
@@ -15,6 +15,11 @@ runCodeTest({
 			{
 				selector: 'decl[prop="z-index"]',
 				message: 'z-index not allowed.'
+			},
+			{
+				selector: 'decl[prop="zoom"]',
+				// @ts-ignore
+				message: (node) => `${node.prop} not allowed.`
 			}
 		]
 	],
@@ -38,7 +43,7 @@ runCodeTest({
 					endColumn: 23,
 					endLine: 1,
 					line: 1,
-					text: messages.report('Anchors not allowed.')
+					text: 'Anchors not allowed. (plugin/no-restricted-syntax)'
 				}
 			]
 		},
@@ -50,7 +55,19 @@ runCodeTest({
 					endColumn: 15,
 					endLine: 1,
 					line: 1,
-					text: messages.report('z-index not allowed.')
+					text: 'z-index not allowed. (plugin/no-restricted-syntax)'
+				}
+			]
+		},
+		{
+			input: 'b { zoom:1.5 }',
+			result: [
+				{
+					column: 5,
+					endColumn: 13,
+					endLine: 1,
+					line: 1,
+					text: 'zoom not allowed. (plugin/no-restricted-syntax)'
 				}
 			]
 		}


### PR DESCRIPTION
Hi again.

I'd like to use function error messages for better error messaging. This is a partial PR (no docs), but I've tested it in the test suite and in my application. 

I passed the entire node/`Declaration` to a message function, since the PostCSS selectors can be so varied. Usage example:

```js
const noFloats = (node) => `Use a modern layout algorithm instead of "${node.prop}". In cases where a float layout is the best choice, please disable this rule per line.`;
const noNonStandardProps = (node) => `"${node.prop}" is a non-standard property. Please replace with a standards equivalent.`;

const config = "plugin/no-restricted-syntax": [
  {
    selector: "decl[prop='float']",
    message: noFloats,
  },
  {
    selector: "decl[prop='clear']",
    message: noFloats,
  },
  {
    selector: "decl[prop='zoom']",
    message: noNonStandardProps,
  },
  {
    selector: "decl[prop='max-zoom']",
    message: noNonStandardProps,
  },
  // String messages still work
  { 
    selector: "decl[prop='direction']",
    message: "Don't use the direction property"
  },
];
```

What do you think about making this addition?